### PR TITLE
Change ssl to be a boolean type

### DIFF
--- a/library/mongodb_replication.py
+++ b/library/mongodb_replication.py
@@ -325,7 +325,7 @@ def main():
             host_name=dict(default='localhost'),
             host_port=dict(default='27017'),
             host_type=dict(default='replica', choices=['replica','arbiter']),
-            ssl=dict(default='false'),
+            ssl = dict(type='bool', default='false'),
             build_indexes = dict(type='bool', default='yes'),
             hidden = dict(type='bool', default='no'),
             priority = dict(default='1.0'),


### PR DESCRIPTION
ssl was not a boolean. Setting ssl: true resulted in a failure to validate :
validate_boolean_or_string\r\n    \"'true' or 'false'\" % (option,))\r\nValueError: The value of ssl must be 'true' or 'false'\r\n